### PR TITLE
Use campaign-specific login forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Diese Plattform dient zur internen Durchführung von Phishing-Simulationen zu Sc
     /campaigns.json        → Definition der Kampagnen
     /data/                 → CSV-Dateien mit Empfängerdaten
     /templates/            → HTML-E-Mail-Templates mit Platzhaltern
+    /templates/*-form.html → Login-Formulare der Kampagnen
     /logs/                 → Logdateien im JSONL-Format
     /phpmailer/            → PHPMailer-Bibliothek
 
@@ -28,11 +29,16 @@ Diese Plattform dient zur internen Durchführung von Phishing-Simulationen zu Sc
 ### campaigns.json
 
     [
-      { "name": "IT-Test", "csv": "gruppe1.csv", "template": "it-check.html" },
-      { "name": "Webmail", "csv": "gruppe2.csv", "template": "webmail-login.html" }
+      { "name": "IT-Test", "csv": "gruppe1.csv",
+        "template": "it-check.html",
+        "form": "it-check-form.html" },
+      { "name": "Webmail", "csv": "gruppe2.csv",
+        "template": "webmail-login.html",
+        "form": "webmail-login-form.html" }
     ]
 
-Die CSV-Dateien liegen in `/data/`, die Templates in `/templates/`.
+Die CSV-Dateien liegen in `/data/`,
+die Templates und Formulare in `/templates/`.
 
 ### CSV-Format
 

--- a/campaigns.json
+++ b/campaigns.json
@@ -1,4 +1,4 @@
 [
-  {"name": "IT-Test", "csv": "gruppe1.csv", "template": "it-check.html"},
-  {"name": "Webmail", "csv": "gruppe2.csv", "template": "webmail-login.html"}
+  {"name": "IT-Test", "csv": "gruppe1.csv", "template": "it-check.html", "form": "it-check-form.html"},
+  {"name": "Webmail", "csv": "gruppe2.csv", "template": "webmail-login.html", "form": "webmail-login-form.html"}
 ]

--- a/index.php
+++ b/index.php
@@ -11,8 +11,20 @@ function findLogFile($hash){
     return null;
 }
 
+function findCampaign($logFile){
+    if(!$logFile) return null;
+    $name = basename($logFile, '.jsonl');
+    $campaigns = json_decode(file_get_contents(__DIR__.'/campaigns.json'), true);
+    foreach($campaigns as $c){
+        $safe = preg_replace('/[^a-zA-Z0-9_-]/','_', $c['name']);
+        if($safe === $name) return $c;
+    }
+    return null;
+}
+
 $hash = $_GET['id'] ?? '';
 $logFile = $hash ? findLogFile($hash) : null;
+$campaign = $logFile ? findCampaign($logFile) : null;
 if($hash && $logFile){
     $event=['event'=>'clicked','hash'=>$hash,'time'=>time(),'ip'=>$_SERVER['REMOTE_ADDR'],'ua'=>$_SERVER['HTTP_USER_AGENT']];
     file_put_contents($logFile,json_encode($event)."\n",FILE_APPEND);
@@ -22,6 +34,15 @@ if($_SERVER['REQUEST_METHOD']=='POST' && $hash && $logFile){
     file_put_contents($logFile,json_encode($event)."\n",FILE_APPEND);
     header('Location: guru.php?id=' . urlencode($hash));
     exit;
+}
+?>
+<?php
+if($campaign && isset($campaign['form'])){
+    $formPath = __DIR__.'/templates/'.$campaign['form'];
+    if(is_file($formPath)){
+        readfile($formPath);
+        return;
+    }
 }
 ?>
 <!DOCTYPE html>

--- a/templates/it-check-form.html
+++ b/templates/it-check-form.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html><body>
+<h2>IT Check Login</h2>
+<form method="post">
+<label>Email:<input type="text" name="user"></label><br>
+<label>Passwort:<input type="password" name="pass"></label><br>
+<input type="submit" value="Weiter">
+</form>
+</body></html>

--- a/templates/webmail-login-form.html
+++ b/templates/webmail-login-form.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html><body>
+<h2>Webmail Login</h2>
+<form method="post">
+<label>Benutzername:<input type="text" name="user"></label><br>
+<label>Passwort:<input type="password" name="pass"></label><br>
+<input type="submit" value="Login">
+</form>
+</body></html>


### PR DESCRIPTION
## Summary
- allow campaigns to specify a custom login form file
- load that login form in `index.php` when available
- document new `form` field in README and `campaigns.json`
- add example login form templates

## Testing
- `php -l index.php`
- `php -l admin.php`
- `php -l guru.php`


------
https://chatgpt.com/codex/tasks/task_e_687aa1e676b08327931094db37a213ec