### PR TITLE
Add email send error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ Beispiel:
 
 - `index.php` loggt Klicks + zeigt ein Fakeformular
 - Formular sendet an `index.php`, loggt Eingaben, leitet zu `guru.php`
-- Protokollierung erfolgt in `/logs/<kampagne>.jsonl`
+ - Protokollierung erfolgt in `/logs/<kampagne>.jsonl`
+   (inkl. Fehlermeldungen `send_error` bzw. `send_exception` bei Problemen
+   beim Mailversand)
 
 ## Live-Dashboard
 

--- a/admin.php
+++ b/admin.php
@@ -51,13 +51,31 @@ if (isset($_GET['send'])) {
         $mail->isHTML(true);
         $mail->Subject = $camp['name'];
         $mail->Body = $body;
-        if($mail->send()){
+        try {
+            if($mail->send()){
+                $event = [
+                    'event' => 'sent',
+                    'email' => $data['email'],
+                    'first' => $data['vorname'],
+                    'last'  => $data['nachname'],
+                    'hash'  => $hash,
+                    'time'  => time()
+                ];
+                file_put_contents($logFile, json_encode($event) . "\n", FILE_APPEND);
+            } else {
+                $event = [
+                    'event' => 'send_error',
+                    'email' => $data['email'],
+                    'error' => $mail->ErrorInfo,
+                    'time'  => time()
+                ];
+                file_put_contents($logFile, json_encode($event) . "\n", FILE_APPEND);
+            }
+        } catch(Exception $e) {
             $event = [
-                'event' => 'sent',
+                'event' => 'send_exception',
                 'email' => $data['email'],
-                'first' => $data['vorname'],
-                'last'  => $data['nachname'],
-                'hash'  => $hash,
+                'error' => $e->getMessage(),
                 'time'  => time()
             ];
             file_put_contents($logFile, json_encode($event) . "\n", FILE_APPEND);

--- a/stats.php
+++ b/stats.php
@@ -5,7 +5,7 @@ foreach($logs as $file){
     $name = basename($file,'.jsonl');
     $lines = file($file,FILE_IGNORE_NEW_LINES);
     $hashMap = [];
-    $stats = ['total_sent'=>0,'clicked'=>0,'submitted'=>0,'last'=>0,'entries'=>[]];
+    $stats = ['total_sent'=>0,'clicked'=>0,'submitted'=>0,'errors'=>0,'last'=>0,'entries'=>[]];
     foreach($lines as $line){
         $d = json_decode($line,true);
         if(!$d) continue;
@@ -13,6 +13,9 @@ foreach($logs as $file){
         if($d['event']=='sent'){
             $stats['total_sent']++;
             $hashMap[$d['hash']] = ['email'=>$d['email']];
+        }
+        if($d['event']=='send_error' || $d['event']=='send_exception'){
+            $stats['errors']++;
         }
         if($d['event']=='clicked'){
             $stats['clicked']++;


### PR DESCRIPTION
## Summary
- log errors and exceptions when PHPMailer send fails
- count send errors in statistics
- document new logging behaviour in README

## Testing
- `php -l admin.php`
- `php -l stats.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_6880ce2d9070832787948bed6ea28d07