### PR TITLE
Store each campaign send in separate log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Beispiel:
 
 - `index.php` loggt Klicks + zeigt ein Fakeformular
 - Formular sendet an `index.php`, loggt Eingaben, leitet zu `guru.php`
- - Protokollierung erfolgt in `/logs/<kampagne>.jsonl`
+ - Protokollierung erfolgt in `/logs/<kampagne>-<timestamp>.jsonl`
    (inkl. Fehlermeldungen `send_error` bzw. `send_exception` bei Problemen
    beim Mailversand)
 

--- a/admin.php
+++ b/admin.php
@@ -20,7 +20,7 @@ if (isset($_GET['send'])) {
     $tpl = file_get_contents($tplPath);
     $handle = fopen($csvPath,'r');
     $header = fgetcsv($handle, 0, ',', '"', '\\');
-    $logFile = __DIR__.'/logs/'.safeName($camp['name']).'.jsonl';
+    $logFile = __DIR__.'/logs/'.safeName($camp['name']).'-'.date('Ymd-His').'.jsonl';
     $success = 0;
     $total = 0;
     $errors = [];

--- a/index.php
+++ b/index.php
@@ -14,6 +14,7 @@ function findLogFile($hash){
 function findCampaign($logFile){
     if(!$logFile) return null;
     $name = basename($logFile, '.jsonl');
+    $name = preg_replace('/-\d{8}-\d{6}$/', '', $name);
     $campaigns = json_decode(file_get_contents(__DIR__.'/campaigns.json'), true);
     foreach($campaigns as $c){
         $safe = preg_replace('/[^a-zA-Z0-9_-]/','_', $c['name']);

--- a/roadmap.md
+++ b/roadmap.md
@@ -18,7 +18,7 @@ Diese Datei dokumentiert, welche Funktionen laut `README.md` vorhanden sein soll
 ## Offene Punkte
 
 1. **Auswertungen pro Kampage**
-   - Auswertungen sollen pro gesendeter Kampagne erfolgen. Das muss irgendwie mit Kampagnenname und Zeitstempel sichergestellt werden. Aktuell wird alles in eine kampagnenname.jsonl Datei geschrieben. Wobei .jsonl fast wie ein Tippfehler aussieht. 
+   - *Erledigt:* Logdateien erhalten jetzt einen Zeitstempel (Format `kampagnenname-YYYYMMDD-HHMMSS.jsonl`). Dadurch existiert für jeden Versand eine eigene Datei.
 3. **Absicherung von `admin.php`**
    - Gemäß README sollte der Zugriff geschützt werden (z.B. per `.htaccess`). Dies fehlt aktuell komplett im Repository.
    - Umsetzung erfolgt, wenn alle Funktionen implementiert sind und erfolgreiche Testläuft erfolgt sind.


### PR DESCRIPTION
## Summary
- log name now includes timestamp to keep each send separate
- link log file back to campaign even with timestamped names
- document new log naming in README
- update roadmap to mark per-campaign logs as done

## Testing
- `php -l admin.php`
- `php -l index.php`
- `php -l stats.php`


------
https://chatgpt.com/codex/tasks/task_e_6880fae7cc44832780d22bc06568dbc2