### PR TITLE
Introduce email subject in campaigns

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,20 @@ Diese Plattform dient zur internen Durchführung von Phishing-Simulationen zu Sc
     [
       { "name": "IT-Test", "csv": "gruppe1.csv",
         "email_template": "it-check.html",
-        "login_form": "it-check-form.html" },
+        "login_form": "it-check-form.html",
+        "subject": "Überprüfung Ihrer IT-Zugangsdaten" },
       { "name": "Webmail", "csv": "gruppe2.csv",
         "email_template": "webmail-login.html",
-        "login_form": "webmail-login-form.html" }
+        "login_form": "webmail-login-form.html",
+        "subject": "Bestätigung Ihres Webmail-Kontos" }
     ]
 
 Die CSV-Dateien liegen in `/data/`,
 die Templates und Formulare in `/templates/`.
 
 Die Felder `email_template` und `login_form` verweisen jeweils auf die
-HTML-Dateien in diesem Verzeichnis.
+HTML-Dateien in diesem Verzeichnis. Mit `subject` kann der Betreff der
+versendeten E-Mail festgelegt werden.
 
 ### CSV-Format
 

--- a/admin.php
+++ b/admin.php
@@ -53,7 +53,7 @@ if (isset($_GET['send'])) {
         $mail->setFrom($cfg['from_email'],$cfg['from_name']);
         $mail->addAddress($data['email']);
         $mail->isHTML(true);
-        $mail->Subject = $camp['name'];
+        $mail->Subject = $camp['subject'] ?? $camp['name'];
         $mail->Body = $body;
         try {
             $total++;

--- a/campaigns.json
+++ b/campaigns.json
@@ -1,4 +1,4 @@
 [
-  {"name": "IT-Test", "csv": "gruppe1.csv", "email_template": "it-test.html", "login_form": "it-test-form.html"},
-  {"name": "Webmail", "csv": "gruppe2.csv", "email_template": "webmail.html", "login_form": "webmail-form.html"}
+  {"name": "IT-Test", "csv": "gruppe1.csv", "email_template": "it-test.html", "login_form": "it-test-form.html", "subject": "Überprüfung Ihrer IT-Zugangsdaten"},
+  {"name": "Webmail", "csv": "gruppe2.csv", "email_template": "webmail.html", "login_form": "webmail-form.html", "subject": "Bestätigung Ihres Webmail-Kontos"}
 ]


### PR DESCRIPTION
## Summary
- add `subject` entries to `campaigns.json`
- use subject field in `admin.php`
- document subject usage in README

## Testing
- `php -l admin.php`
- `php -l index.php`
- `php -l stats.php`
- `php -l guru.php`
- `php -l config.php`

------
https://chatgpt.com/codex/tasks/task_e_6880fc31bdb4832785fe20c9374aa532