### PR TITLE
Fix double counting of clicks

### DIFF
--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@ function findCampaign($logFile){
 $hash = $_GET['id'] ?? '';
 $logFile = $hash ? findLogFile($hash) : null;
 $campaign = $logFile ? findCampaign($logFile) : null;
-if($hash && $logFile){
+if($hash && $logFile && $_SERVER['REQUEST_METHOD'] === 'GET'){
     $event=['event'=>'clicked','hash'=>$hash,'time'=>time(),'ip'=>$_SERVER['REMOTE_ADDR'],'ua'=>$_SERVER['HTTP_USER_AGENT']];
     file_put_contents($logFile,json_encode($event)."\n",FILE_APPEND);
 }


### PR DESCRIPTION
## Summary
- only log click events on GET requests to prevent duplicate clicks when the form is submitted

## Testing
- `php -l index.php`
- `php -l stats.php`
- `php -l admin.php`


------
https://chatgpt.com/codex/tasks/task_e_688281e3c70c8327b70fe5210b0fafa1